### PR TITLE
Make running vagrant commands from subdirs work

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,11 +2,11 @@
 # vi: set ft=ruby :
 
 require 'yaml'
-require './src/colorize.rb'
-require './src/hash.rb'
-require './src/file.rb'
-require './src/project.rb'
-require './src/config.rb'
+require_relative 'src/colorize.rb'
+require_relative 'src/hash.rb'
+require_relative 'src/file.rb'
+require_relative 'src/project.rb'
+require_relative 'src/config.rb'
 
 current_dir = File.dirname(File.expand_path(__FILE__))
 


### PR DESCRIPTION
Before this fix, running vagrant from a subdirectory failed with:
webapp-development-box (master=) > cd project/
project (master=) > vagrant ssh
Vagrant failed to initialize at a very early stage:

There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /Users/ruben/src/webapp-development-box/Vagrantfile
Line number: 0
Message: LoadError: cannot load such file -- ./src/colorize.rb

Using imports relative to the Vagrantfile fixes this.